### PR TITLE
ESUI-902. Avoid multiple HemsManager instances.

### DIFF
--- a/nymea-app/ui/RootItem.qml
+++ b/nymea-app/ui/RootItem.qml
@@ -131,6 +131,13 @@ Item {
                     readonly property Engine engine: configuredHost.engine
                     readonly property Engine _engine: configuredHost.engine // In case a child cannot use "engine"
 
+                    HemsManager {
+                        id: hemsManagerInternal
+                        engine: _engine
+                    }
+
+                    readonly property HemsManager hemsManager: hemsManagerInternal
+
                     Binding {
                         target: nymeaDiscovery
                         property: "discovering"

--- a/nymea-app/ui/system/GeneralSettingsPage.qml
+++ b/nymea-app/ui/system/GeneralSettingsPage.qml
@@ -38,8 +38,6 @@ import "../components"
 SettingsPageBase {
     id: root
 
-    property HemsManager hemsManager
-
     title: qsTr("General settings")
     busy: d.pendingCommand !== -1
 


### PR DESCRIPTION
Instantiate one HemsManager instance in RootItem (similar to the Engine instance) to make that HemsManager instance available for all screens/components belonging to that specific backend connection. This avoids the multiple HemsManager instances which were used in the code up until now and thus a lot of unnecessarily repeated communication.