### PR TITLE
ESUI-1167. Add EebusLimitGuard instantiation to RootItem

### DIFF
--- a/nymea-app/ui/RootItem.qml
+++ b/nymea-app/ui/RootItem.qml
@@ -33,6 +33,7 @@ import NymeaApp.Utils
 
 import "components"
 import "connection"
+import "thingconfiguration"
 
 Item {
     id: root
@@ -132,6 +133,13 @@ Item {
                     }
 
                     readonly property HemsManager hemsManager: hemsManagerInternal
+
+                    EebusLimitGuard {
+                        id: eebusLimitGuardInternal
+                        engine: _engine
+                    }
+
+                    readonly property EebusLimitGuard eebusLimitGuard: eebusLimitGuardInternal
 
                     Binding {
                         target: nymeaDiscovery


### PR DESCRIPTION
Instantiate EebusLimitGuard alongside HemsManager so it runs globally for all EEBUS device setup flows. Expose it as a readonly property (eebusLimitGuard) on the SwipeView delegate, making it context-accessible to all child QML pages (SetupEEBUSWizard, AddNewThings).