### PR TITLE
ESUI-1337: Suppress Windows console window and attach parent console …

### DIFF
--- a/nymea-app/main.cpp
+++ b/nymea-app/main.cpp
@@ -57,6 +57,15 @@
 
 #include "logging.h"
 
+#ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
+#include <cstdio>
+#include <windows.h>
+// <combaseapi.h> defines `interface` as `struct`, which collides with
+// parameter names in nymea-app headers (e.g. thingmanager.h, networkdevices.h).
+#undef interface
+#endif
+
 #ifdef OVERLAY_QMLTYPES
 #include OVERLAY_QMLTYPES
 #endif
@@ -66,6 +75,18 @@ NYMEA_LOGGING_CATEGORY(qml, "qml")
 
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_WIN
+    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+        const bool stdoutRedirected = freopen("CONOUT$", "w", stdout) != nullptr;
+        const bool stderrRedirected = freopen("CONOUT$", "w", stderr) != nullptr;
+        if (!stdoutRedirected) {
+            OutputDebugStringA("Failed to redirect stdout to parent console.\n");
+        }
+        if (!stderrRedirected) {
+            OutputDebugStringA("Failed to redirect stderr to parent console.\n");
+        }
+    }
+#endif
 
 #ifdef Q_OS_OSX
     qputenv("QT_WEBVIEW_PLUGIN", "native");

--- a/nymea-app/nymea-app.pro
+++ b/nymea-app/nymea-app.pro
@@ -224,6 +224,9 @@ ubports: {
 }
 
 win32 {
+    CONFIG -= console
+    CONFIG += windows
+
     HEADERS += platformintegration/generic/platformhelpergeneric.h
     SOURCES += platformintegration/generic/platformhelpergeneric.cpp
 


### PR DESCRIPTION
…output

Backport of the ESUI-1337 changes from main to release/2.0.

The release/2.0 branch uses qmake instead of CMake, so the equivalent of qt_add_executable(... WIN32) is achieved via 'CONFIG -= console' and 'CONFIG += windows' in the win32 scope of nymea-app.pro.

main.cpp gains the same logic as on main: attach to the parent console (if any) on Windows so stdout/stderr output remains visible when launching from a terminal, and undef the 'interface' macro defined by <combaseapi.h> to avoid collisions with nymea-app headers.