### PR TITLE
ESUI-1369: consume system-bar insets in page headers/footers

### DIFF
--- a/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
+++ b/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
@@ -52,10 +52,11 @@ public class NymeaAppActivity extends QtActivity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.w(TAG, "Create activity");
+        Log.d(TAG, "onCreate: SDK_INT=" + Build.VERSION.SDK_INT);
         int themeId = resolveStyleResource("NormalTheme");
         if (themeId != 0) {
             setTheme(themeId);
+            Log.d(TAG, "onCreate: applied NormalTheme (id=" + themeId + ")");
         } else {
             Log.w(TAG, "NormalTheme style missing, falling back to system theme");
             setTheme(android.R.style.Theme_DeviceDefault_DayNight);
@@ -66,9 +67,12 @@ public class NymeaAppActivity extends QtActivity
             // PlatformHelper.topPadding() will return 0 since the system handles insets.
             WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
             mDecorFitsSystemWindows = true;
+            Log.d(TAG, "onCreate: API 35 - opted out of edge-to-edge");
         }
         // On API 36+, setDecorFitsSystemWindows(true) is ignored - edge-to-edge is mandatory.
         // mDecorFitsSystemWindows stays false so topPadding() reads the actual insets.
+        Log.d(TAG, "onCreate: mDecorFitsSystemWindows=" + mDecorFitsSystemWindows
+                + " darkModeEnabled=" + darkModeEnabled());
         this.context = getApplicationContext();
     }
 
@@ -247,6 +251,9 @@ public class NymeaAppActivity extends QtActivity
      * legacy SystemUiVisibility flags up to that point.
      */
     public void setLightStatusBar(final boolean darkIcons) {
+        Log.d(TAG, "setLightStatusBar: darkIcons=" + darkIcons
+                + " SDK_INT=" + Build.VERSION.SDK_INT
+                + " darkModeEnabled=" + darkModeEnabled());
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -256,6 +263,9 @@ public class NymeaAppActivity extends QtActivity
                         WindowCompat.getInsetsController(window, decorView);
                 if (controller != null) {
                     controller.setAppearanceLightStatusBars(darkIcons);
+                    Log.d(TAG, "setLightStatusBar: applied darkIcons=" + darkIcons);
+                } else {
+                    Log.w(TAG, "setLightStatusBar: WindowInsetsControllerCompat is null");
                 }
             }
         });
@@ -270,6 +280,9 @@ public class NymeaAppActivity extends QtActivity
      * the version check internally.
      */
     public void setLightNavigationBar(final boolean darkIcons) {
+        Log.d(TAG, "setLightNavigationBar: darkIcons=" + darkIcons
+                + " SDK_INT=" + Build.VERSION.SDK_INT
+                + " darkModeEnabled=" + darkModeEnabled());
         runOnUiThread(new Runnable() {
             @Override
             public void run() {
@@ -279,6 +292,9 @@ public class NymeaAppActivity extends QtActivity
                         WindowCompat.getInsetsController(window, decorView);
                 if (controller != null) {
                     controller.setAppearanceLightNavigationBars(darkIcons);
+                    Log.d(TAG, "setLightNavigationBar: applied darkIcons=" + darkIcons);
+                } else {
+                    Log.w(TAG, "setLightNavigationBar: WindowInsetsControllerCompat is null");
                 }
             }
         });

--- a/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
+++ b/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
@@ -18,6 +18,9 @@ import android.content.BroadcastReceiver;
 import android.location.LocationManager;
 import androidx.core.content.FileProvider;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
+import android.view.View;
+import android.view.Window;
 import android.view.WindowInsets;
 import android.graphics.Insets;
 
@@ -233,6 +236,52 @@ public class NymeaAppActivity extends QtActivity
         }
 
         return windowInsets.getStableInsetRight();
+    }
+
+    /**
+     * Tells Android whether the status bar icons (clock, signal, battery)
+     * should be drawn dark (true) or light (false). Pass `true` when the
+     * area behind the status bar is light, `false` when it is dark.
+     *
+     * No-op below API 23 (M); WindowInsetsControllerCompat falls back to
+     * legacy SystemUiVisibility flags up to that point.
+     */
+    public void setLightStatusBar(final boolean darkIcons) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Window window = getWindow();
+                View decorView = window.getDecorView();
+                WindowInsetsControllerCompat controller =
+                        WindowCompat.getInsetsController(window, decorView);
+                if (controller != null) {
+                    controller.setAppearanceLightStatusBars(darkIcons);
+                }
+            }
+        });
+    }
+
+    /**
+     * Tells Android whether the navigation/gesture bar icons should be
+     * drawn dark (true) or light (false). Pass `true` when the area
+     * behind the navigation bar is light, `false` when it is dark.
+     *
+     * No-op below API 26 (O); WindowInsetsControllerCompat handles
+     * the version check internally.
+     */
+    public void setLightNavigationBar(final boolean darkIcons) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Window window = getWindow();
+                View decorView = window.getDecorView();
+                WindowInsetsControllerCompat controller =
+                        WindowCompat.getInsetsController(window, decorView);
+                if (controller != null) {
+                    controller.setAppearanceLightNavigationBars(darkIcons);
+                }
+            }
+        });
     }
 
     private void logStaticInitClassesMetadata() {

--- a/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
+++ b/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
@@ -33,7 +33,7 @@ import org.qtproject.qt.android.bindings.QtActivity;
 public class NymeaAppActivity extends QtActivity
 {
     private static final String TAG = "nymea-app: NymeaAppActivity";
-    private static final String ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v3";
+    private static final String ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v4";
     private static Context context = null;
     private boolean mDecorFitsSystemWindows = false;
 

--- a/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
+++ b/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
@@ -33,7 +33,6 @@ import org.qtproject.qt.android.bindings.QtActivity;
 public class NymeaAppActivity extends QtActivity
 {
     private static final String TAG = "nymea-app: NymeaAppActivity";
-    private static final String ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v4";
     private static Context context = null;
     private boolean mDecorFitsSystemWindows = false;
 
@@ -53,11 +52,9 @@ public class NymeaAppActivity extends QtActivity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: SDK_INT=" + Build.VERSION.SDK_INT);
         int themeId = resolveStyleResource("NormalTheme");
         if (themeId != 0) {
             setTheme(themeId);
-            Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: applied NormalTheme (id=" + themeId + ")");
         } else {
             Log.w(TAG, "NormalTheme style missing, falling back to system theme");
             setTheme(android.R.style.Theme_DeviceDefault_DayNight);
@@ -68,12 +65,9 @@ public class NymeaAppActivity extends QtActivity
             // PlatformHelper.topPadding() will return 0 since the system handles insets.
             WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
             mDecorFitsSystemWindows = true;
-            Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: API 35 - opted out of edge-to-edge");
         }
         // On API 36+, setDecorFitsSystemWindows(true) is ignored - edge-to-edge is mandatory.
         // mDecorFitsSystemWindows stays false so topPadding() reads the actual insets.
-        Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: mDecorFitsSystemWindows=" + mDecorFitsSystemWindows
-                + " darkModeEnabled=" + darkModeEnabled());
         this.context = getApplicationContext();
     }
 
@@ -252,7 +246,7 @@ public class NymeaAppActivity extends QtActivity
      * legacy SystemUiVisibility flags up to that point.
      */
     public void setLightStatusBar(final boolean darkIcons) {
-        Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightStatusBar: darkIcons=" + darkIcons
+        Log.d(TAG, "setLightStatusBar: darkIcons=" + darkIcons
                 + " SDK_INT=" + Build.VERSION.SDK_INT
                 + " darkModeEnabled=" + darkModeEnabled());
         runOnUiThread(new Runnable() {
@@ -264,9 +258,9 @@ public class NymeaAppActivity extends QtActivity
                         WindowCompat.getInsetsController(window, decorView);
                 if (controller != null) {
                     controller.setAppearanceLightStatusBars(darkIcons);
-                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightStatusBar: applied darkIcons=" + darkIcons);
+                    Log.d(TAG, "setLightStatusBar: applied darkIcons=" + darkIcons);
                 } else {
-                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightStatusBar: WindowInsetsControllerCompat is null");
+                    Log.d(TAG, "setLightStatusBar: WindowInsetsControllerCompat is null");
                 }
             }
         });
@@ -281,7 +275,7 @@ public class NymeaAppActivity extends QtActivity
      * the version check internally.
      */
     public void setLightNavigationBar(final boolean darkIcons) {
-        Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightNavigationBar: darkIcons=" + darkIcons
+        Log.d(TAG, "setLightNavigationBar: darkIcons=" + darkIcons
                 + " SDK_INT=" + Build.VERSION.SDK_INT
                 + " darkModeEnabled=" + darkModeEnabled());
         runOnUiThread(new Runnable() {
@@ -293,9 +287,9 @@ public class NymeaAppActivity extends QtActivity
                         WindowCompat.getInsetsController(window, decorView);
                 if (controller != null) {
                     controller.setAppearanceLightNavigationBars(darkIcons);
-                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightNavigationBar: applied darkIcons=" + darkIcons);
+                    Log.d(TAG, "setLightNavigationBar: applied darkIcons=" + darkIcons);
                 } else {
-                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightNavigationBar: WindowInsetsControllerCompat is null");
+                    Log.d(TAG, "setLightNavigationBar: WindowInsetsControllerCompat is null");
                 }
             }
         });

--- a/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
+++ b/nymea-app/platformintegration/android/java/io/guh/nymeaapp/NymeaAppActivity.java
@@ -33,6 +33,7 @@ import org.qtproject.qt.android.bindings.QtActivity;
 public class NymeaAppActivity extends QtActivity
 {
     private static final String TAG = "nymea-app: NymeaAppActivity";
+    private static final String ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v3";
     private static Context context = null;
     private boolean mDecorFitsSystemWindows = false;
 
@@ -52,11 +53,11 @@ public class NymeaAppActivity extends QtActivity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.d(TAG, "onCreate: SDK_INT=" + Build.VERSION.SDK_INT);
+        Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: SDK_INT=" + Build.VERSION.SDK_INT);
         int themeId = resolveStyleResource("NormalTheme");
         if (themeId != 0) {
             setTheme(themeId);
-            Log.d(TAG, "onCreate: applied NormalTheme (id=" + themeId + ")");
+            Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: applied NormalTheme (id=" + themeId + ")");
         } else {
             Log.w(TAG, "NormalTheme style missing, falling back to system theme");
             setTheme(android.R.style.Theme_DeviceDefault_DayNight);
@@ -67,11 +68,11 @@ public class NymeaAppActivity extends QtActivity
             // PlatformHelper.topPadding() will return 0 since the system handles insets.
             WindowCompat.setDecorFitsSystemWindows(getWindow(), true);
             mDecorFitsSystemWindows = true;
-            Log.d(TAG, "onCreate: API 35 - opted out of edge-to-edge");
+            Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: API 35 - opted out of edge-to-edge");
         }
         // On API 36+, setDecorFitsSystemWindows(true) is ignored - edge-to-edge is mandatory.
         // mDecorFitsSystemWindows stays false so topPadding() reads the actual insets.
-        Log.d(TAG, "onCreate: mDecorFitsSystemWindows=" + mDecorFitsSystemWindows
+        Log.w(TAG, ESUI_1369_BUILD_MARKER + " onCreate: mDecorFitsSystemWindows=" + mDecorFitsSystemWindows
                 + " darkModeEnabled=" + darkModeEnabled());
         this.context = getApplicationContext();
     }
@@ -251,7 +252,7 @@ public class NymeaAppActivity extends QtActivity
      * legacy SystemUiVisibility flags up to that point.
      */
     public void setLightStatusBar(final boolean darkIcons) {
-        Log.d(TAG, "setLightStatusBar: darkIcons=" + darkIcons
+        Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightStatusBar: darkIcons=" + darkIcons
                 + " SDK_INT=" + Build.VERSION.SDK_INT
                 + " darkModeEnabled=" + darkModeEnabled());
         runOnUiThread(new Runnable() {
@@ -263,9 +264,9 @@ public class NymeaAppActivity extends QtActivity
                         WindowCompat.getInsetsController(window, decorView);
                 if (controller != null) {
                     controller.setAppearanceLightStatusBars(darkIcons);
-                    Log.d(TAG, "setLightStatusBar: applied darkIcons=" + darkIcons);
+                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightStatusBar: applied darkIcons=" + darkIcons);
                 } else {
-                    Log.w(TAG, "setLightStatusBar: WindowInsetsControllerCompat is null");
+                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightStatusBar: WindowInsetsControllerCompat is null");
                 }
             }
         });
@@ -280,7 +281,7 @@ public class NymeaAppActivity extends QtActivity
      * the version check internally.
      */
     public void setLightNavigationBar(final boolean darkIcons) {
-        Log.d(TAG, "setLightNavigationBar: darkIcons=" + darkIcons
+        Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightNavigationBar: darkIcons=" + darkIcons
                 + " SDK_INT=" + Build.VERSION.SDK_INT
                 + " darkModeEnabled=" + darkModeEnabled());
         runOnUiThread(new Runnable() {
@@ -292,9 +293,9 @@ public class NymeaAppActivity extends QtActivity
                         WindowCompat.getInsetsController(window, decorView);
                 if (controller != null) {
                     controller.setAppearanceLightNavigationBars(darkIcons);
-                    Log.d(TAG, "setLightNavigationBar: applied darkIcons=" + darkIcons);
+                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightNavigationBar: applied darkIcons=" + darkIcons);
                 } else {
-                    Log.w(TAG, "setLightNavigationBar: WindowInsetsControllerCompat is null");
+                    Log.w(TAG, ESUI_1369_BUILD_MARKER + " setLightNavigationBar: WindowInsetsControllerCompat is null");
                 }
             }
         });

--- a/nymea-app/platformintegration/android/platformhelperandroid.cpp
+++ b/nymea-app/platformintegration/android/platformhelperandroid.cpp
@@ -91,11 +91,20 @@ PlatformHelperAndroid::PlatformHelperAndroid(QObject *parent) : PlatformHelper(p
     // }
 
     connect(qApp, &QApplication::applicationStateChanged, this, [this](Qt::ApplicationState state){
-        qCritical() << "----> Application state changed" << state;
         if (state == Qt::ApplicationActive) {
             emit locationServicesEnabledChanged();
             updateSafeAreaPadding();
         }
+    });
+
+    // Re-apply system bar icon colours whenever the system dark mode changes.
+    // On API 31-35 the correct icon colour depends on the system theme (not
+    // the app colour), so we need to reapply even if topPanelColor hasn't
+    // changed (e.g. the app has a fixed light/dark theme).
+    connect(this, &PlatformHelper::darkModeEnabledChanged, this, [this]() {
+        qDebug("[ESUI-1369] darkModeEnabledChanged: re-applying system bar icon colours");
+        setTopPanelColor(topPanelColor());
+        setBottomPanelColor(bottomPanelColor());
     });
 
     if (QScreen *screen = qApp->primaryScreen()) {
@@ -229,17 +238,33 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
 {
     PlatformHelper::setTopPanelColor(color);
 
-    // Only Android 16+ is expected to run fully edge-to-edge here. On older
-    // releases the system/theme still owns the system-bar appearance, and our
-    // color-based override can fight with that.
     const jint sdkInt = QJniObject::getStaticField<jint>("android/os/Build$VERSION", "SDK_INT");
-    if (sdkInt < 36) {
+
+    bool darkIcons;
+    if (sdkInt >= 36) {
+        // API 36+: window is fully edge-to-edge; the app background IS visible
+        // behind the status bar, so base icon colour on the app's background luminance.
+        darkIcons = qGray(color.rgb()) > 128;
+        qDebug("[ESUI-1369] status bar icons: api=%d trigger=topPanelColor "
+               "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
+               (int)sdkInt, color.rgb() & 0xFFFFFF, qGray(color.rgb()),
+               darkIcons ? "true" : "false");
+    } else if (sdkInt >= 31) {
+        // API 31-35: the status bar has its own background drawn by
+        // Theme.DeviceDefault.DayNight (follows system theme). Qt's Material
+        // plugin independently sets icon colour based on Material.theme (app
+        // theme). When app theme != system theme that produces wrong contrast.
+        // Override with the system-theme-correct value.
+        const bool systemDark = darkModeEnabled();
+        darkIcons = !systemDark;
+        qDebug("[ESUI-1369] status bar icons: api=%d trigger=topPanelColor "
+               "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
+               (int)sdkInt, color.rgb() & 0xFFFFFF,
+               systemDark ? "true" : "false", darkIcons ? "true" : "false");
+    } else {
+        qDebug("[ESUI-1369] status bar icons: api=%d skipped (< 31)", (int)sdkInt);
         return;
     }
-
-    // Tell Android whether the status-bar icons should be dark or light based
-    // on the luminance of the colour that paints behind the bar.
-    const bool darkIcons = qGray(color.rgb()) > 128;
 
     QJniObject activity = QJniObject::callStaticObjectMethod(
             "org/qtproject/qt/android/QtNative",
@@ -247,6 +272,8 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
             "()Landroid/app/Activity;");
     if (activity.isValid()) {
         activity.callMethod<void>("setLightStatusBar", "(Z)V", darkIcons);
+    } else {
+        qWarning("[ESUI-1369] status bar icons: could not get activity");
     }
 }
 
@@ -255,11 +282,25 @@ void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
     PlatformHelper::setBottomPanelColor(color);
 
     const jint sdkInt = QJniObject::getStaticField<jint>("android/os/Build$VERSION", "SDK_INT");
-    if (sdkInt < 36) {
+
+    bool darkIcons;
+    if (sdkInt >= 36) {
+        darkIcons = qGray(color.rgb()) > 128;
+        qDebug("[ESUI-1369] navigation bar icons: api=%d trigger=bottomPanelColor "
+               "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
+               (int)sdkInt, color.rgb() & 0xFFFFFF, qGray(color.rgb()),
+               darkIcons ? "true" : "false");
+    } else if (sdkInt >= 31) {
+        const bool systemDark = darkModeEnabled();
+        darkIcons = !systemDark;
+        qDebug("[ESUI-1369] navigation bar icons: api=%d trigger=bottomPanelColor "
+               "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
+               (int)sdkInt, color.rgb() & 0xFFFFFF,
+               systemDark ? "true" : "false", darkIcons ? "true" : "false");
+    } else {
+        qDebug("[ESUI-1369] navigation bar icons: api=%d skipped (< 31)", (int)sdkInt);
         return;
     }
-
-    const bool darkIcons = qGray(color.rgb()) > 128;
 
     QJniObject activity = QJniObject::callStaticObjectMethod(
             "org/qtproject/qt/android/QtNative",
@@ -267,6 +308,8 @@ void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
             "()Landroid/app/Activity;");
     if (activity.isValid()) {
         activity.callMethod<void>("setLightNavigationBar", "(Z)V", darkIcons);
+    } else {
+        qWarning("[ESUI-1369] navigation bar icons: could not get activity");
     }
 }
 

--- a/nymea-app/platformintegration/android/platformhelperandroid.cpp
+++ b/nymea-app/platformintegration/android/platformhelperandroid.cpp
@@ -44,7 +44,7 @@
 #define SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR 0x00000010
 
 static PlatformHelperAndroid *m_instance = nullptr;
-static constexpr const char *ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v3";
+static constexpr const char *ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v4";
 
 static JNINativeMethod methods[] = {
     { "darkModeEnabledChangedJNI", "()V", (void *)PlatformHelperAndroid::darkModeEnabledChangedJNI },

--- a/nymea-app/platformintegration/android/platformhelperandroid.cpp
+++ b/nymea-app/platformintegration/android/platformhelperandroid.cpp
@@ -44,6 +44,7 @@
 #define SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR 0x00000010
 
 static PlatformHelperAndroid *m_instance = nullptr;
+static constexpr const char *ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v3";
 
 static JNINativeMethod methods[] = {
     { "darkModeEnabledChangedJNI", "()V", (void *)PlatformHelperAndroid::darkModeEnabledChangedJNI },
@@ -84,6 +85,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* /*reserved*/)
 PlatformHelperAndroid::PlatformHelperAndroid(QObject *parent) : PlatformHelper(parent)
 {
     m_instance = this;
+    qWarning("%s PlatformHelperAndroid constructed", ESUI_1369_BUILD_MARKER);
 
     // QString notificationData = QNativeInterface::QAndroidApplication::context().callMethod<jstring>("notificationData", "()Ljava/lang/String;").toString();
     // if (!notificationData.isNull()) {
@@ -102,7 +104,7 @@ PlatformHelperAndroid::PlatformHelperAndroid(QObject *parent) : PlatformHelper(p
     // the app colour), so we need to reapply even if topPanelColor hasn't
     // changed (e.g. the app has a fixed light/dark theme).
     connect(this, &PlatformHelper::darkModeEnabledChanged, this, [this]() {
-        qDebug("[ESUI-1369] darkModeEnabledChanged: re-applying system bar icon colours");
+        qWarning("%s darkModeEnabledChanged: re-applying system bar icon colours", ESUI_1369_BUILD_MARKER);
         setTopPanelColor(topPanelColor());
         setBottomPanelColor(bottomPanelColor());
     });
@@ -245,8 +247,9 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
         // API 36+: window is fully edge-to-edge; the app background IS visible
         // behind the status bar, so base icon colour on the app's background luminance.
         darkIcons = qGray(color.rgb()) > 128;
-        qDebug("[ESUI-1369] status bar icons: api=%d trigger=topPanelColor "
-               "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
+        qWarning("%s status bar icons: api=%d trigger=topPanelColor "
+                 "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
+               ESUI_1369_BUILD_MARKER,
                (int)sdkInt, color.rgb() & 0xFFFFFF, qGray(color.rgb()),
                darkIcons ? "true" : "false");
     } else if (sdkInt >= 31) {
@@ -257,12 +260,13 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
         // Override with the system-theme-correct value.
         const bool systemDark = darkModeEnabled();
         darkIcons = !systemDark;
-        qDebug("[ESUI-1369] status bar icons: api=%d trigger=topPanelColor "
-               "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
+        qWarning("%s status bar icons: api=%d trigger=topPanelColor "
+                 "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
+               ESUI_1369_BUILD_MARKER,
                (int)sdkInt, color.rgb() & 0xFFFFFF,
                systemDark ? "true" : "false", darkIcons ? "true" : "false");
     } else {
-        qDebug("[ESUI-1369] status bar icons: api=%d skipped (< 31)", (int)sdkInt);
+        qWarning("%s status bar icons: api=%d skipped (< 31)", ESUI_1369_BUILD_MARKER, (int)sdkInt);
         return;
     }
 
@@ -273,7 +277,7 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
     if (activity.isValid()) {
         activity.callMethod<void>("setLightStatusBar", "(Z)V", darkIcons);
     } else {
-        qWarning("[ESUI-1369] status bar icons: could not get activity");
+        qWarning("%s status bar icons: could not get activity", ESUI_1369_BUILD_MARKER);
     }
 }
 
@@ -286,19 +290,21 @@ void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
     bool darkIcons;
     if (sdkInt >= 36) {
         darkIcons = qGray(color.rgb()) > 128;
-        qDebug("[ESUI-1369] navigation bar icons: api=%d trigger=bottomPanelColor "
-               "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
+        qWarning("%s navigation bar icons: api=%d trigger=bottomPanelColor "
+                 "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
+               ESUI_1369_BUILD_MARKER,
                (int)sdkInt, color.rgb() & 0xFFFFFF, qGray(color.rgb()),
                darkIcons ? "true" : "false");
     } else if (sdkInt >= 31) {
         const bool systemDark = darkModeEnabled();
         darkIcons = !systemDark;
-        qDebug("[ESUI-1369] navigation bar icons: api=%d trigger=bottomPanelColor "
-               "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
+        qWarning("%s navigation bar icons: api=%d trigger=bottomPanelColor "
+                 "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
+               ESUI_1369_BUILD_MARKER,
                (int)sdkInt, color.rgb() & 0xFFFFFF,
                systemDark ? "true" : "false", darkIcons ? "true" : "false");
     } else {
-        qDebug("[ESUI-1369] navigation bar icons: api=%d skipped (< 31)", (int)sdkInt);
+        qWarning("%s navigation bar icons: api=%d skipped (< 31)", ESUI_1369_BUILD_MARKER, (int)sdkInt);
         return;
     }
 
@@ -309,7 +315,7 @@ void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
     if (activity.isValid()) {
         activity.callMethod<void>("setLightNavigationBar", "(Z)V", darkIcons);
     } else {
-        qWarning("[ESUI-1369] navigation bar icons: could not get activity");
+        qWarning("%s navigation bar icons: could not get activity", ESUI_1369_BUILD_MARKER);
     }
 }
 

--- a/nymea-app/platformintegration/android/platformhelperandroid.cpp
+++ b/nymea-app/platformintegration/android/platformhelperandroid.cpp
@@ -229,10 +229,16 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
 {
     PlatformHelper::setTopPanelColor(color);
 
-    // Tell Android whether the status-bar icons should be dark or light
-    // based on the luminance of the colour that paints behind the bar.
-    // The bar itself is transparent (see styles.xml) so the area behind it
-    // is `app.color` (bound to `topPanelColor` in Nymea.qml).
+    // Only Android 16+ is expected to run fully edge-to-edge here. On older
+    // releases the system/theme still owns the system-bar appearance, and our
+    // color-based override can fight with that.
+    const jint sdkInt = QJniObject::getStaticField<jint>("android/os/Build$VERSION", "SDK_INT");
+    if (sdkInt < 36) {
+        return;
+    }
+
+    // Tell Android whether the status-bar icons should be dark or light based
+    // on the luminance of the colour that paints behind the bar.
     const bool darkIcons = qGray(color.rgb()) > 128;
 
     QJniObject activity = QJniObject::callStaticObjectMethod(
@@ -247,6 +253,11 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
 void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
 {
     PlatformHelper::setBottomPanelColor(color);
+
+    const jint sdkInt = QJniObject::getStaticField<jint>("android/os/Build$VERSION", "SDK_INT");
+    if (sdkInt < 36) {
+        return;
+    }
 
     const bool darkIcons = qGray(color.rgb()) > 128;
 

--- a/nymea-app/platformintegration/android/platformhelperandroid.cpp
+++ b/nymea-app/platformintegration/android/platformhelperandroid.cpp
@@ -229,41 +229,34 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
 {
     PlatformHelper::setTopPanelColor(color);
 
-    // if (QtAndroid::androidSdkVersion() < 21)
-    //     return;
+    // Tell Android whether the status-bar icons should be dark or light
+    // based on the luminance of the colour that paints behind the bar.
+    // The bar itself is transparent (see styles.xml) so the area behind it
+    // is `app.color` (bound to `topPanelColor` in Nymea.qml).
+    const bool darkIcons = qGray(color.rgb()) > 128;
 
-    // QtAndroid::runOnAndroidThread([=]() {
-    //     QJniObject window = getAndroidWindow();
-    //     window.callMethod<void>("addFlags", "(I)V", FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-    //     window.callMethod<void>("clearFlags", "(I)V", FLAG_TRANSLUCENT_STATUS);
-    //     window.callMethod<void>("setStatusBarColor", "(I)V", color.rgba());
-    // });
-
-    // if (((color.red() * 299 + color.green() * 587 + color.blue() * 114) / 1000) > 123) {
-    //     setTopPanelTheme(Light);
-    // } else {
-    //     setTopPanelTheme(Dark);
-    // }
+    QJniObject activity = QJniObject::callStaticObjectMethod(
+            "org/qtproject/qt/android/QtNative",
+            "activity",
+            "()Landroid/app/Activity;");
+    if (activity.isValid()) {
+        activity.callMethod<void>("setLightStatusBar", "(Z)V", darkIcons);
+    }
 }
 
 void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
 {
     PlatformHelper::setBottomPanelColor(color);
 
-    // if (QtAndroid::androidSdkVersion() < 21)
-    //     return;
+    const bool darkIcons = qGray(color.rgb()) > 128;
 
-    // QtAndroid::runOnAndroidThread([=]() {
-    //     QJniObject window = getAndroidWindow();
-    //     window.callMethod<void>("clearFlags", "(I)V", FLAG_TRANSLUCENT_NAVIGATION);
-    //     window.callMethod<void>("setNavigationBarColor", "(I)V", color.rgba());
-
-    //     if (((color.red() * 299 + color.green() * 587 + color.blue() * 114) / 1000) > 123) {
-    //         setBottomPanelTheme(Light);
-    //     } else {
-    //         setBottomPanelTheme(Dark);
-    //     }
-    // });
+    QJniObject activity = QJniObject::callStaticObjectMethod(
+            "org/qtproject/qt/android/QtNative",
+            "activity",
+            "()Landroid/app/Activity;");
+    if (activity.isValid()) {
+        activity.callMethod<void>("setLightNavigationBar", "(Z)V", darkIcons);
+    }
 }
 
 void PlatformHelperAndroid::setTopPanelTheme(PlatformHelperAndroid::Theme theme)

--- a/nymea-app/platformintegration/android/platformhelperandroid.cpp
+++ b/nymea-app/platformintegration/android/platformhelperandroid.cpp
@@ -44,7 +44,6 @@
 #define SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR 0x00000010
 
 static PlatformHelperAndroid *m_instance = nullptr;
-static constexpr const char *ESUI_1369_BUILD_MARKER = "[ESUI-1369] android-system-bar-cache-marker-v4";
 
 static JNINativeMethod methods[] = {
     { "darkModeEnabledChangedJNI", "()V", (void *)PlatformHelperAndroid::darkModeEnabledChangedJNI },
@@ -85,7 +84,6 @@ JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* /*reserved*/)
 PlatformHelperAndroid::PlatformHelperAndroid(QObject *parent) : PlatformHelper(parent)
 {
     m_instance = this;
-    qWarning("%s PlatformHelperAndroid constructed", ESUI_1369_BUILD_MARKER);
 
     // QString notificationData = QNativeInterface::QAndroidApplication::context().callMethod<jstring>("notificationData", "()Ljava/lang/String;").toString();
     // if (!notificationData.isNull()) {
@@ -104,7 +102,6 @@ PlatformHelperAndroid::PlatformHelperAndroid(QObject *parent) : PlatformHelper(p
     // the app colour), so we need to reapply even if topPanelColor hasn't
     // changed (e.g. the app has a fixed light/dark theme).
     connect(this, &PlatformHelper::darkModeEnabledChanged, this, [this]() {
-        qWarning("%s darkModeEnabledChanged: re-applying system bar icon colours", ESUI_1369_BUILD_MARKER);
         setTopPanelColor(topPanelColor());
         setBottomPanelColor(bottomPanelColor());
     });
@@ -247,9 +244,8 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
         // API 36+: window is fully edge-to-edge; the app background IS visible
         // behind the status bar, so base icon colour on the app's background luminance.
         darkIcons = qGray(color.rgb()) > 128;
-        qWarning("%s status bar icons: api=%d trigger=topPanelColor "
-                 "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
-               ESUI_1369_BUILD_MARKER,
+        qDebug("status bar icons: api=%d trigger=topPanelColor "
+               "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
                (int)sdkInt, color.rgb() & 0xFFFFFF, qGray(color.rgb()),
                darkIcons ? "true" : "false");
     } else if (sdkInt >= 31) {
@@ -260,13 +256,12 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
         // Override with the system-theme-correct value.
         const bool systemDark = darkModeEnabled();
         darkIcons = !systemDark;
-        qWarning("%s status bar icons: api=%d trigger=topPanelColor "
-                 "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
-               ESUI_1369_BUILD_MARKER,
+        qDebug("status bar icons: api=%d trigger=topPanelColor "
+               "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
                (int)sdkInt, color.rgb() & 0xFFFFFF,
                systemDark ? "true" : "false", darkIcons ? "true" : "false");
     } else {
-        qWarning("%s status bar icons: api=%d skipped (< 31)", ESUI_1369_BUILD_MARKER, (int)sdkInt);
+        qDebug("status bar icons: api=%d skipped (< 31)", (int)sdkInt);
         return;
     }
 
@@ -277,7 +272,7 @@ void PlatformHelperAndroid::setTopPanelColor(const QColor &color)
     if (activity.isValid()) {
         activity.callMethod<void>("setLightStatusBar", "(Z)V", darkIcons);
     } else {
-        qWarning("%s status bar icons: could not get activity", ESUI_1369_BUILD_MARKER);
+        qDebug("status bar icons: could not get activity");
     }
 }
 
@@ -290,21 +285,19 @@ void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
     bool darkIcons;
     if (sdkInt >= 36) {
         darkIcons = qGray(color.rgb()) > 128;
-        qWarning("%s navigation bar icons: api=%d trigger=bottomPanelColor "
-                 "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
-               ESUI_1369_BUILD_MARKER,
+        qDebug("navigation bar icons: api=%d trigger=bottomPanelColor "
+               "color=#%06x luminance=%d -> darkIcons=%s (edge-to-edge)",
                (int)sdkInt, color.rgb() & 0xFFFFFF, qGray(color.rgb()),
                darkIcons ? "true" : "false");
     } else if (sdkInt >= 31) {
         const bool systemDark = darkModeEnabled();
         darkIcons = !systemDark;
-        qWarning("%s navigation bar icons: api=%d trigger=bottomPanelColor "
-                 "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
-               ESUI_1369_BUILD_MARKER,
+        qDebug("navigation bar icons: api=%d trigger=bottomPanelColor "
+               "color=#%06x systemDark=%s -> darkIcons=%s (system-theme override)",
                (int)sdkInt, color.rgb() & 0xFFFFFF,
                systemDark ? "true" : "false", darkIcons ? "true" : "false");
     } else {
-        qWarning("%s navigation bar icons: api=%d skipped (< 31)", ESUI_1369_BUILD_MARKER, (int)sdkInt);
+        qDebug("navigation bar icons: api=%d skipped (< 31)", (int)sdkInt);
         return;
     }
 
@@ -315,7 +308,7 @@ void PlatformHelperAndroid::setBottomPanelColor(const QColor &color)
     if (activity.isValid()) {
         activity.callMethod<void>("setLightNavigationBar", "(Z)V", darkIcons);
     } else {
-        qWarning("%s navigation bar icons: could not get activity", ESUI_1369_BUILD_MARKER);
+        qDebug("navigation bar icons: could not get activity");
     }
 }
 

--- a/nymea-app/ui/MainMenu.qml
+++ b/nymea-app/ui/MainMenu.qml
@@ -75,8 +75,8 @@ Drawer {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.topMargin: PlatformHelper.topPadding
-        anchors.leftMargin: PlatformHelper.leftPadding
+        anchors.topMargin: SafeArea.margins.top
+        anchors.leftMargin: SafeArea.margins.left
         spacing: 0
 
         Rectangle {

--- a/nymea-app/ui/MainPage.qml
+++ b/nymea-app/ui/MainPage.qml
@@ -141,7 +141,7 @@ Page {
                 left: parent.left
                 leftMargin: Style.smallMargins
                 top: parent.top
-                topMargin: Style.smallMargins
+                topMargin: Style.smallMargins + contentContainer.safeAreaTop
             }
 
             onClicked: {
@@ -158,7 +158,7 @@ Page {
             source: "qrc:/styles/%1/logo-wide.svg".arg(styleController.currentStyle)
             anchors {
                 top: parent.top;
-                topMargin: (contentContainer.headerSize - height) / 2
+                topMargin: contentContainer.safeAreaTop + (contentContainer.headerSize - height) / 2
                 right: parent.right
                 rightMargin: Style.margins
             }
@@ -170,7 +170,7 @@ Page {
 
         Row {
             id: additionalIcons
-            anchors { right: parent.right; top: parent.top }
+            anchors { right: parent.right; top: parent.top; topMargin: contentContainer.safeAreaTop }
             visible: !d.configOverlay
             width: visible ? implicitWidth : 0
 
@@ -210,7 +210,7 @@ Page {
                 right: parent.right
                 left: parent.left
                 top: parent.top
-                topMargin: contentContainer.headerSize - 1
+                topMargin: contentContainer.safeAreaTop + contentContainer.headerSize - 1
             }
             height: 1
             color: Style.colors.menu_Header_Footer_Border
@@ -388,9 +388,20 @@ Page {
 
         property int headerSize: 64
         property int footerSize: 58
+        // Top inset reserved for the system status bar / display cutout.
+        // On Android <= 15 and on iOS without notch this is 0; on Android 16+
+        // or iOS with notch it is the actual inset returned by Qt.
+        // The interactive header band keeps its `headerSize` (64) and is
+        // shifted down by this amount; the blur backdrop extends upward by
+        // this amount so it reaches the physical top edge of the screen.
+        property int safeAreaTop: SafeArea.margins.top
 
         readonly property int scrollOffset: swipeView.currentItem ? swipeView.currentItem.item.contentY : 0
         readonly property int headerBlurSize: Math.min(headerSize, scrollOffset * 2)
+        // Total visual extent of the header overlay (status-bar inset plus
+        // the part of the interactive band currently covered by blur).
+        readonly property int visualHeaderHeight: safeAreaTop
+                                                  + (d.configOverlay ? headerSize : headerBlurSize)
 
         Background {
             anchors.fill: parent
@@ -423,6 +434,12 @@ Page {
 
                     Binding {
                         target: mainViewLoader.item
+                        property: "topMargin"
+                        value: contentContainer.safeAreaTop + contentContainer.headerSize
+                    }
+
+                    Binding {
+                        target: mainViewLoader.item
                         property: "bottomMargin"
                         value: root.navigationFooterHeight
                     }
@@ -451,9 +468,9 @@ Page {
     ShaderEffectSource {
         id: headerBlurSource
         width: contentContainer.width
-        height: d.configOverlay ? contentContainer.headerSize : contentContainer.headerBlurSize
+        height: contentContainer.visualHeaderHeight
         sourceItem: d.blurEnabled ? contentContainer : null
-        sourceRect: Qt.rect(0, 0, contentContainer.width, d.configOverlay ? contentContainer.headerSize : contentContainer.headerBlurSize)
+        sourceRect: Qt.rect(0, 0, contentContainer.width, contentContainer.visualHeaderHeight)
         visible: false
     }
 
@@ -463,7 +480,7 @@ Page {
             top: parent.top;
             right: parent.right;
         }
-        height: d.configOverlay ? contentContainer.headerSize : contentContainer.headerBlurSize
+        height: contentContainer.visualHeaderHeight
         radius: 40
         transparentBorder: false
         source: d.blurEnabled ? headerBlurSource : null
@@ -477,7 +494,7 @@ Page {
             top: parent.top
             right: parent.right
         }
-        height: d.configOverlay ? contentContainer.headerSize : contentContainer.headerBlurSize
+        height: contentContainer.visualHeaderHeight
         color: Style.colors.menu_Header_Footer_Background
     }
 
@@ -492,7 +509,7 @@ Page {
                 id: configListView
                 anchors.fill: parent
                 model: mainMenuModel
-                topMargin: contentContainer.headerSize
+                topMargin: contentContainer.safeAreaTop + contentContainer.headerSize
                 bottomMargin: contentContainer.footerSize
 
                 property bool dragging: draggingIndex >= 0

--- a/nymea-app/ui/MainPage.qml
+++ b/nymea-app/ui/MainPage.qml
@@ -38,8 +38,8 @@ import "mainviews"
 Page {
     id: root
 
-    // Removing the background from this page only because the MainViewBase adds it again in
-    // a deepter layer as we need to include it in the blurring of the header and footer.
+    // Removing the background from this page only because MainViewBase adds it again in
+    // a deeper layer so the header and footer chrome can sample it for the blur effect.
     // We don't want to paint the background on the entire screen twice (overdraw is costly)
     background: null
     bottomPadding: 0  // footer lives at RootItem level; main views handle spacing themselves
@@ -133,6 +133,10 @@ Page {
         //         app.mainMenu.open()
         //     }
         // }
+
+        // Top inset reserved for the system status bar / display cutout.
+        // The header chrome is shifted down by this amount; the page itself
+        // still reaches the physical screen edge.
         RoundButton {
             id: menuButton
             icon.source: "qrc:/icons/menu.svg"
@@ -392,14 +396,13 @@ Page {
         // On Android <= 15 and on iOS without notch this is 0; on Android 16+
         // or iOS with notch it is the actual inset returned by Qt.
         // The interactive header band keeps its `headerSize` (64) and is
-        // shifted down by this amount; the blur backdrop extends upward by
-        // this amount so it reaches the physical top edge of the screen.
+        // shifted down by this amount so it stays below the system bar.
         property int safeAreaTop: SafeArea.margins.top
 
         readonly property int scrollOffset: swipeView.currentItem ? swipeView.currentItem.item.contentY : 0
         readonly property int headerBlurSize: Math.min(headerSize, scrollOffset * 2)
         // Total visual extent of the header overlay (status-bar inset plus
-        // the part of the interactive band currently covered by blur).
+        // the blurred interactive band).
         readonly property int visualHeaderHeight: safeAreaTop
                                                   + (d.configOverlay ? headerSize : headerBlurSize)
 

--- a/nymea-app/ui/Nymea.qml
+++ b/nymea-app/ui/Nymea.qml
@@ -40,8 +40,8 @@ ApplicationWindow {
     height: Qt.platform.os === "ios" ? Screen.height : 580
     // The ApplicationWindow draws edge-to-edge. System-bar insets are consumed
     // inside the page headers and the navigation footer (see RootItem and the
-    // CoHeader component) so the background and blur effects can extend below
-    // the status bar and above the gesture/navigation bar.
+    // CoHeader component) so the app chrome can reach the screen edges while
+    // the system bars remain system-drawn.
     maximumWidth: 768
     minimumWidth: 360
     minimumHeight: 580

--- a/nymea-app/ui/Nymea.qml
+++ b/nymea-app/ui/Nymea.qml
@@ -38,10 +38,10 @@ ApplicationWindow {
     visible: true
     width: Qt.platform.os === "ios" ? Screen.width : 360
     height: Qt.platform.os === "ios" ? Screen.height : 580
-    topPadding: Qt.platform.os === "ios" ? 0 : SafeArea.margins.top
-    bottomPadding: Qt.platform.os === "ios" ? 0 : SafeArea.margins.bottom
-    leftPadding: Qt.platform.os === "ios" ? 0 : SafeArea.margins.left
-    rightPadding: Qt.platform.os === "ios" ? 0 : SafeArea.margins.right
+    // The ApplicationWindow draws edge-to-edge. System-bar insets are consumed
+    // inside the page headers and the navigation footer (see RootItem and the
+    // CoHeader component) so the background and blur effects can extend below
+    // the status bar and above the gesture/navigation bar.
     maximumWidth: 768
     minimumWidth: 360
     minimumHeight: 580

--- a/nymea-app/ui/Nymea.qml
+++ b/nymea-app/ui/Nymea.qml
@@ -46,7 +46,7 @@ ApplicationWindow {
     minimumWidth: 360
     minimumHeight: 580
     visibility: kioskMode ? ApplicationWindow.FullScreen : settings.viewMode
-    color: "magenta" // ESUI-1369 diagnostic: revert before merging
+    color: Material.background
     title: Configuration.appName
 
     Material.theme: NymeaUtils.isDark(Style.backgroundColor) ? Material.Dark : Material.Light

--- a/nymea-app/ui/Nymea.qml
+++ b/nymea-app/ui/Nymea.qml
@@ -46,7 +46,7 @@ ApplicationWindow {
     minimumWidth: 360
     minimumHeight: 580
     visibility: kioskMode ? ApplicationWindow.FullScreen : settings.viewMode
-    color: Material.background
+    color: "magenta" // ESUI-1369 diagnostic: revert before merging
     title: Configuration.appName
 
     Material.theme: NymeaUtils.isDark(Style.backgroundColor) ? Material.Dark : Material.Light

--- a/nymea-app/ui/RootItem.qml
+++ b/nymea-app/ui/RootItem.qml
@@ -91,8 +91,8 @@ Item {
         // root so page content does not slide under them. Top/bottom
         // insets are intentionally NOT applied here; they are handled by
         // each page's header (CoHeader / MainPage header) and by the
-        // navigation footer below so the blur backdrops can extend to the
-        // physical screen edges.
+        // navigation footer below so the app chrome can reach the screen
+        // edges while the system bars stay system-drawn.
         anchors.leftMargin: SafeArea.margins.left
         anchors.rightMargin: SafeArea.margins.right
 
@@ -223,9 +223,9 @@ Item {
                         id: navigationFooterContainer
                         readonly property bool shown: navigationFooter.shown || navbarControlsLoader.active
                         // The footer reaches the physical bottom of the screen so
-                        // its blur backdrop covers the area behind the system
-                        // gesture/navigation bar. Interactive children are
-                        // pushed above the inset via safeAreaBottom.
+                        // the footer chrome stays flush with the edge. Interactive
+                        // children are pushed above the gesture/navigation inset
+                        // via safeAreaBottom.
                         readonly property int safeAreaBottom: SafeArea.margins.bottom
                         anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
                         height: (navbarControlsLoader.active ? navbarControlsLoader.height + 2 * Style.margins : 0)

--- a/nymea-app/ui/RootItem.qml
+++ b/nymea-app/ui/RootItem.qml
@@ -86,10 +86,15 @@ Item {
     ColumnLayout {
         anchors.fill: parent
 
-        anchors.topMargin: PlatformHelper.topPadding
-        anchors.bottomMargin: PlatformHelper.bottomPadding
-        anchors.leftMargin: PlatformHelper.leftPadding
-        anchors.rightMargin: PlatformHelper.rightPadding
+        // The window is edge-to-edge. Left/right system insets (display
+        // cutout, gesture areas on the sides) are still consumed at the
+        // root so page content does not slide under them. Top/bottom
+        // insets are intentionally NOT applied here; they are handled by
+        // each page's header (CoHeader / MainPage header) and by the
+        // navigation footer below so the blur backdrops can extend to the
+        // physical screen edges.
+        anchors.leftMargin: SafeArea.margins.left
+        anchors.rightMargin: SafeArea.margins.right
 
         spacing: 0
 
@@ -217,9 +222,15 @@ Item {
                     Item {
                         id: navigationFooterContainer
                         readonly property bool shown: navigationFooter.shown || navbarControlsLoader.active
+                        // The footer reaches the physical bottom of the screen so
+                        // its blur backdrop covers the area behind the system
+                        // gesture/navigation bar. Interactive children are
+                        // pushed above the inset via safeAreaBottom.
+                        readonly property int safeAreaBottom: SafeArea.margins.bottom
                         anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
                         height: (navbarControlsLoader.active ? navbarControlsLoader.height + 2 * Style.margins : 0)
                                 + (navigationFooter.shown ? navigationFooter.height : 0)
+                                + safeAreaBottom
                         visible: shown
 
                         Rectangle {
@@ -262,7 +273,10 @@ Item {
                                                           && mainPage.tabsModel !== undefined
                                                           && (mainPage.tabsModel.count > 1 || mainPage.hasConfigOverlay)
                             visible: shown
-                            anchors { left: parent.left; right: parent.right; bottom: parent.bottom }
+                            anchors {
+                                left: parent.left; right: parent.right
+                                bottom: parent.bottom; bottomMargin: navigationFooterContainer.safeAreaBottom
+                            }
                             height: shown ? 58 : 0
 
                             RowLayout {

--- a/nymea-app/ui/components/NymeaHeader.qml
+++ b/nymea-app/ui/components/NymeaHeader.qml
@@ -30,7 +30,11 @@ import Nymea
 
 Item {
     id: root
-    implicitHeight: layout.implicitHeight + infoPane.height
+    // System status-bar / display-cutout inset. The interactive row is
+    // shifted down by this amount; the page background extends behind the
+    // status bar.
+    property int safeAreaTop: SafeArea.margins.top
+    implicitHeight: safeAreaTop + layout.implicitHeight + infoPane.height
     property string text
     property alias backButtonVisible: backButton.visible
     property alias menuButtonVisible: menuButton.visible
@@ -56,7 +60,7 @@ Item {
 
     RowLayout {
         id: layout
-        anchors { left: parent.left; top: parent.top; right: parent.right }
+        anchors { left: parent.left; top: parent.top; topMargin: root.safeAreaTop; right: parent.right }
 
         HeaderButton {
             id: menuButton

--- a/nymea-app/ui/components/NymeaHeader.qml
+++ b/nymea-app/ui/components/NymeaHeader.qml
@@ -31,8 +31,8 @@ import Nymea
 Item {
     id: root
     // System status-bar / display-cutout inset. The interactive row is
-    // shifted down by this amount; the page background extends behind the
-    // status bar.
+    // shifted down by this amount while the page chrome itself still reaches
+    // the screen edge.
     property int safeAreaTop: SafeArea.margins.top
     implicitHeight: safeAreaTop + layout.implicitHeight + infoPane.height
     property string text

--- a/nymea-app/ui/connection/ConnectPage.qml
+++ b/nymea-app/ui/connection/ConnectPage.qml
@@ -34,6 +34,7 @@ Page {
     id: root
 
     header: ToolBar {
+        topPadding: SafeArea.margins.top
         RowLayout {
             anchors.fill: parent
 


### PR DESCRIPTION
The window now draws edge-to-edge on Android 16+ (mandatory) and on iOS notch devices. To avoid the previously visible white strips above and below the app, the SafeArea insets are no longer applied at the root container (which would double-pad with ApplicationWindow.padding and keep the app background away from the screen edges). Instead, each top-of-screen chrome element grows by SafeArea.margins.top and shifts its content down, and the navigation footer grows by SafeArea.margins.bottom and pushes its tab row above the gesture bar. The blur backdrops therefore extend to the physical screen edges while controls stay tappable.

* Nymea.qml: drop ApplicationWindow padding (was a duplicate of the per-page inset handling and only used on non-iOS).
* RootItem.qml: drop top/bottom anchor margins on the main column; extend the navigation footer container by SafeArea.margins.bottom so the blur covers the gesture bar.
* MainPage.qml: factor a safeAreaTop in contentContainer; the interactive header band keeps its 64px size and is shifted down by safeAreaTop, while the blur/mask cover the full visualHeaderHeight. Propagate the new topMargin to mainview loaders.
* MainMenu.qml: switch the drawer top/left margins from PlatformHelper to SafeArea.margins so the listing reacts to inset changes (orientation, IME) without a JNI round-trip.
* NymeaHeader.qml: pre-login pages (ConnectPage, LoginPage, SetupWizard) inherit the same status-bar inset behaviour.
* ConnectPage.qml: ToolBar header gets a topPadding equal to the status-bar inset.

Effect on Android <= 15 and iOS without notch: SafeArea.margins.top returns 0, so headers/footers keep their previous height and layout.